### PR TITLE
Change nginx deps to chef_nginx

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ version          "0.1.0"
 
 supports 'ubuntu'
 
-%w{ nginx perl runit bluepill }.each do |dep|
+%w{ chef_nginx perl runit bluepill }.each do |dep|
   depends dep
 end
 


### PR DESCRIPTION
The nginx cookbook is deprecated for the chef_nginx. So this cookbooks should use the supported chef_nginx dependancy.